### PR TITLE
Patches to recent changes

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -166,7 +166,7 @@ button {
     border: 1px solid var(--white-2);
     background-color: transparent;
     border-radius: 8px;
-    font-family: Inter, sans-serif;
+    font-family: "Google Sans", sans-serif;
     padding: 4px 8px;
     cursor: pointer;
 }

--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -31,13 +31,13 @@ const baseurl = `https://github.com/ElyPrismLauncher/Launcher/releases/download/
 const os = detectOS();
 if (os === "windows") {
     download_a_element.href = `${baseurl}/PineconeMC-Windows-MSVC-Setup-${version}.exe`;
-    download_span_element.innerHTML = "<small>Windows<sup>64, MSVC</sup></small> Setup";
+    download_span_element.innerHTML = "<small>Windows<sup>x64, MSVC</sup></small> Setup";
 } else if (os === "macos") {
     download_a_element.href = `${baseurl}/PineconeMC-macOS-${version}.dmg`;
     download_span_element.innerHTML = "<small>macOS</small> Disk Image";
 } else {
     download_a_element.href = `${baseurl}/PineconeMC-Linux-x86_64.AppImage`;
-    download_span_element.innerHTML = "<small>Linux<sup>86_64</sup></small> AppImage";
+    download_span_element.innerHTML = "<small>Linux<sup>x64</sup></small> AppImage";
 }
 
 document.getElementById("linux-64-appimage").href = `${baseurl}/PineconeMC-Linux-x86_64.AppImage`;

--- a/download/index.html
+++ b/download/index.html
@@ -91,7 +91,7 @@
                 </a>
                 <br>
                 <a id="macos-zip">
-                    <button><img src="/assets/svg/folder_zip.svg" alt=""> Portable <sup>.zip</sup></button>
+                    <button><img src="/assets/svg/folder_zip.svg" alt=""> Archive <sup>.zip</sup></button>
                 </a>
             </td>
             <td>


### PR DESCRIPTION
apparently Inter is not cool anymore but it was still used in buttons
macOS does not have "Portable" releases, the two assets are the same except for storage format (and also DMG has a symlink to Applications for easier installation)
"64" and "86_64" is confusing when the table uses "x64"